### PR TITLE
Added Flatten method to NativeArray2D

### DIFF
--- a/Arugula.Collections.Tests/NativeArray2DTests.cs
+++ b/Arugula.Collections.Tests/NativeArray2DTests.cs
@@ -78,6 +78,35 @@ namespace Arugula.Collections.Tests
         }
 
         [Test]
+        public void EnumeratesSameOrderAsManaged2DArray()
+        {
+            const int width = 100;
+            const int height = 100;
+            float[,] managedArray = new float[width, height];
+            int i = 0;
+            for (int x = 0; x < width; x++)
+            {
+                for (int y = 0; y < height; y++)
+                {
+                    managedArray[x, y] = i++;
+                }
+            }
+
+            i = 0;
+            foreach (var item in managedArray)
+            {
+                Assert.AreEqual(i++, item);
+            }
+
+            i = 0;
+            NativeArray2D<float> nativeArray = new NativeArray2D<float>(managedArray, Unity.Collections.Allocator.Temp);
+            foreach (var item in nativeArray)
+            {
+                Assert.AreEqual(i++, item);
+            }
+        }
+
+        [Test]
         public void CopyToNativeArray2D()
         {
             var src = new NativeArray2D<int>(10, 3, Unity.Collections.Allocator.Temp);
@@ -306,6 +335,52 @@ namespace Arugula.Collections.Tests
 
                 array.Dispose();
             });
+        }
+
+        [Test]
+        public void FlattensToManagedArray()
+        {
+            var nativeArray2D = new NativeArray2D<float>(10, 10, Unity.Collections.Allocator.Temp);
+            for (int x = 0; x < 10; x++)
+            {
+                for (int y = 0; y < 10; y++)
+                {
+                    nativeArray2D[x, y] = x;
+                }
+            }
+
+            var flattenedArray = nativeArray2D.Flatten();
+
+            Assert.AreEqual(nativeArray2D.Length, flattenedArray.Length);
+            for (int x = 0; x < 10; x++)
+            {
+                for (int y = 0; y < 10; y++)
+                {
+                    Assert.AreEqual(flattenedArray[x * 10 + y], nativeArray2D[x, y]);
+                }
+            }
+        }
+
+        [Test]
+        public void FlattensToNativeArray()
+        {
+            var nativeArray2D = new NativeArray2D<float>(10, 10, Unity.Collections.Allocator.Temp);
+            for (int x = 0; x < 10; x++)
+            {
+                for (int y = 0; y < 10; y++)
+                {
+                    nativeArray2D[x, y] = x;
+                }
+            }
+
+            var flattenedArray = nativeArray2D.Flatten(Unity.Collections.Allocator.Temp);
+
+            Assert.AreEqual(nativeArray2D.Length, flattenedArray.Length);
+            int i = 0;
+            foreach (var item in nativeArray2D)
+            {
+                Assert.AreEqual(flattenedArray[i++], item);
+            }
         }
     }
 }

--- a/Arugula.Collections/NativeArray2D.cs
+++ b/Arugula.Collections/NativeArray2D.cs
@@ -332,6 +332,39 @@ namespace Arugula.Collections
             handle.Free();
         }
 
+        /// <summary>
+        /// Flattens the array into a one-dimensional managed array.
+        /// </summary>
+        public T[] Flatten()
+        {
+#if ENABLE_UNITY_COLLECTIONS_CHECKS
+            AtomicSafetyHandle.CheckReadAndThrow(m_Safety);
+#endif
+            var dst = new T[Length];
+            var handle = GCHandle.Alloc(dst, GCHandleType.Pinned);
+            var addr = handle.AddrOfPinnedObject();
+
+            UnsafeUtility.MemCpy(addr.ToPointer(),
+                                 m_Buffer,
+                                 Length * UnsafeUtility.SizeOf<T>());
+
+            handle.Free();
+            return dst;
+        }
+
+        /// <summary>
+        /// Flattens the array into a one-dimensional NativeArray.
+        /// </summary>
+        public NativeArray<T> Flatten(Allocator allocator)
+        {
+#if ENABLE_UNITY_COLLECTIONS_CHECKS
+            AtomicSafetyHandle.CheckReadAndThrow(m_Safety);
+#endif
+            var dst = new NativeArray<T>(Length, allocator, NativeArrayOptions.UninitializedMemory);
+            UnsafeUtility.MemCpy(dst.GetUnsafePtr(), m_Buffer, Length * UnsafeUtility.SizeOf<T>());
+            return dst;
+        }
+
         public void Dispose()
         {
 #if ENABLE_UNITY_COLLECTIONS_CHECKS

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.0] - 2020-12-13
+### Added
+- Added `Flatten` methods to `NativeArray2D` to create a one-dimensional NativeArray or managed array and copy all elements into the new array.
+## Changed
+- Updated to Burst.1.4.3
 
 ## [0.1.5] - 2020-12-03
 ### Changed

--- a/package.json
+++ b/package.json
@@ -1,12 +1,12 @@
 {
   "name": "com.arugula.collections",
-  "version": "0.1.5",
+  "version": "0.2.0",
   "displayName": "Arugula.Collections",
   "description": "A small library of unmanaged collections for use with Unity DOTS.",
   "unity": "2020.1",
   "unityRelease": "3f1",
   "dependencies": {
-    "com.unity.burst": "1.4.2",
+    "com.unity.burst": "1.4.3",
     "com.unity.collections": "0.14.0-preview.16",
     "com.unity.jobs": "0.7.0-preview.17"
   },


### PR DESCRIPTION
Added Flatten method to NativeArray2D. Creates a one dimensional array and copies all elements to the new array.
Updated to Burst 1.4.3