### PR TITLE
0.3.0

### DIFF
--- a/Arugula.Collections.Tests/NativeHeapTests.cs
+++ b/Arugula.Collections.Tests/NativeHeapTests.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using NUnit.Framework;
+using Unity.Burst;
 using Unity.Collections;
 using Unity.Jobs;
 
@@ -772,60 +773,6 @@ namespace Arugula.Collections.Tests
         }
 
         [Test]
-        public void CreateFromArray_HasSameCount()
-        {
-            var array = new (int, int)[] { (1, 1), (5, 5), (2, 2), (3, 3), (4, 4) };
-            var heap = new NativeHeap<int, int>(array, Allocator.Persistent);
-
-            Assert.AreEqual(array.Length, heap.Count);
-
-            heap.Dispose();
-        }
-
-        [Test]
-        public void CreateFromArray_IsSorted()
-        {
-            var array = new (int, int)[] { (1, 1), (5, 5), (2, 2), (3, 3), (4, 4) };
-            var heap = new NativeHeap<int, int>(array, Allocator.Persistent);
-
-            Assert.AreEqual(1, heap.Pop().value);
-            Assert.AreEqual(2, heap.Pop().value);
-            Assert.AreEqual(3, heap.Pop().value);
-            Assert.AreEqual(4, heap.Pop().value);
-            Assert.AreEqual(5, heap.Pop().value);
-
-            heap.Dispose();
-        }
-
-        [Test]
-        public void CreateFromNativeArray_IsSorted()
-        {
-            var nativeArray = new NativeArray<(int, int)>(new (int, int)[] { (1, 1), (5, 5), (2, 2), (3, 3), (4, 4) }, Allocator.Persistent);
-            var heap = new NativeHeap<int, int>(nativeArray, Allocator.Persistent);
-
-            Assert.AreEqual(1, heap.Pop().value);
-            Assert.AreEqual(2, heap.Pop().value);
-            Assert.AreEqual(3, heap.Pop().value);
-            Assert.AreEqual(4, heap.Pop().value);
-            Assert.AreEqual(5, heap.Pop().value);
-
-            nativeArray.Dispose();
-            heap.Dispose();
-        }
-
-        [Test]
-        public void CreateFromNativeArray_HasSameCount()
-        {
-            var nativeArray = new NativeArray<(int, int)>(new (int, int)[] { (1, 1), (5, 5), (2, 2), (3, 3), (4, 4) }, Allocator.Persistent);
-            var heap = new NativeHeap<int, int>(nativeArray, Allocator.Persistent);
-
-            Assert.AreEqual(nativeArray.Length, heap.Count);
-
-            nativeArray.Dispose();
-            heap.Dispose();
-        }
-
-        [Test]
         public void Push12345_Contains12345()
         {
             var heap = new NativeHeap<int, int>(5, Allocator.Persistent);
@@ -1107,7 +1054,7 @@ namespace Arugula.Collections.Tests
             heap.Push(13, 13);
             heap.Push(9, 9);
 
-            (int, int)[] array = heap.ToArray();
+            HeapNode<int, int>[] array = heap.ToArray();
             Assert.AreEqual(array.Length, heap.Count);
 
             heap.Dispose();
@@ -1124,7 +1071,7 @@ namespace Arugula.Collections.Tests
             heap.Push(13, 13);
             heap.Push(9, 9);
 
-            (int, int)[] array = heap.ToArray();
+            HeapNode<int, int>[] array = heap.ToArray();
             Assert.AreEqual(array.Length, heap.Count);
 
             heap.Dispose();
@@ -1135,7 +1082,7 @@ namespace Arugula.Collections.Tests
         {
             var heap = new NativeHeap<int, int>(Allocator.Persistent);
 
-            (int, int)[] array = heap.ToArray();
+            HeapNode<int, int>[] array = heap.ToArray();
             Assert.AreEqual(0, array.Length);
 
             heap.Dispose();
@@ -1152,7 +1099,7 @@ namespace Arugula.Collections.Tests
             heap.Push(13, 13);
             heap.Push(9, 9);
 
-            NativeArray<(int, int)> nativeArray = heap.ToNativeArray(Allocator.Persistent);
+            NativeArray<HeapNode<int, int>> nativeArray = heap.ToNativeArray(Allocator.Persistent);
             Assert.AreEqual(nativeArray.Length, heap.Count);
 
             nativeArray.Dispose();
@@ -1164,7 +1111,7 @@ namespace Arugula.Collections.Tests
         {
             var heap = new NativeHeap<int, int>(Allocator.Persistent);
 
-            NativeArray<(int, int)> nativeArray = heap.ToNativeArray(Allocator.Persistent);
+            NativeArray<HeapNode<int, int>> nativeArray = heap.ToNativeArray(Allocator.Persistent);
             Assert.AreEqual(0, nativeArray.Length);
 
             nativeArray.Dispose();
@@ -1186,6 +1133,7 @@ namespace Arugula.Collections.Tests
             heap.Dispose();
         }
 
+        [BurstCompile]
         public struct HeapWriteJob : IJob
         {
             public NativeHeap<int, int> heap;
@@ -1195,6 +1143,7 @@ namespace Arugula.Collections.Tests
                 heap.Push(5, 5);
             }
         }
+
         public struct ManagedStructTest : IEquatable<ManagedStructTest>
         {
             public string managedVar;

--- a/Arugula.Collections.Tests/NativeStackTests.cs
+++ b/Arugula.Collections.Tests/NativeStackTests.cs
@@ -40,7 +40,7 @@ namespace Arugula.Collections.Tests
 
             stack.Dispose();
 
-            Assert.Throws<System.InvalidOperationException>(() =>
+            Assert.Throws<System.ObjectDisposedException>(() =>
             {
                 stack.Dispose();
             });
@@ -305,7 +305,7 @@ namespace Arugula.Collections.Tests
             stack.Push(1);
             stack.Dispose(default);
 
-            Assert.Throws<System.InvalidOperationException>(() =>
+            Assert.Throws<System.ObjectDisposedException>(() =>
             {
                 stack.Dispose();
             });

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.0] - 2021-01-01
+### Changed
+- Changed NativeHeap<TValue, TPriority> to not use value tuples because of issues with burst. Replaced with HeapNode<TValue, TPriority> structs.
+### Fixed
+- Fixed some tests
+
 ## [0.2.0] - 2020-12-13
 ### Added
 - Added `Flatten` methods to `NativeArray2D` to create a one-dimensional NativeArray or managed array and copy all elements into the new array.

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2020 Victor
+Copyright (c) 2020 Lord Arugula
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/LICENSE.md.meta
+++ b/LICENSE.md.meta
@@ -1,6 +1,6 @@
 fileFormatVersion: 2
-guid: 1b913e5002f7a104db33da762840c5d5
-DefaultImporter:
+guid: ca3bf50f101718844987e622774cccc0
+TextScriptImporter:
   externalObjects: {}
   userData: 
   assetBundleName: 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "com.arugula.collections",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "displayName": "Arugula.Collections",
   "description": "A small library of unmanaged collections for use with Unity DOTS.",
   "unity": "2020.1",


### PR DESCRIPTION
Previously NativeHeap<TValue, TPriority> used value tuples, but that doesn't work very nicely with Burst (error about struct layout)
Now uses HeapNode<TValue, TPriority> struct.